### PR TITLE
I18n

### DIFF
--- a/module/apps/import-form.ts
+++ b/module/apps/import-form.ts
@@ -38,12 +38,22 @@ export class Import extends Application {
         }
     }
 
+    async parseXmli18n(xmlSource) {
+        let jsonSource = await DataImporter.xml2json(xmlSource);
+        
+        if (DataImporter.CanParseI18n(jsonSource)) {
+            const armorImporter = Import.Importers[2];
+            armorImporter.ParseTranslation(jsonSource);
+        }
+    }
+    
+
     activateListeners(html) {
         html.find("button[type='submit']").on("click", async (event) => {
             event.preventDefault();
 
             let i18nXmlSource = html.find("#i18n-xml-source").val();
-            
+            await this.parseXmli18n(i18nXmlSource);
 
             let xmlSource = html.find("#xml-source").val();
             await this.parseXML(xmlSource);

--- a/module/apps/import-form.ts
+++ b/module/apps/import-form.ts
@@ -33,6 +33,7 @@ export class Import extends Application {
 
         for (const di of Import.Importers) {
             if (di.CanParse(jsonSource)) {
+                di.ExtractTranslation();
                 await di.Parse(jsonSource);
             }
         }
@@ -42,8 +43,7 @@ export class Import extends Application {
         let jsonSource = await DataImporter.xml2json(xmlSource);
         
         if (DataImporter.CanParseI18n(jsonSource)) {
-            const armorImporter = Import.Importers[2];
-            armorImporter.ParseTranslation(jsonSource);
+            DataImporter.ParseTranslation(jsonSource);
         }
     }
     

--- a/module/apps/import-form.ts
+++ b/module/apps/import-form.ts
@@ -42,6 +42,9 @@ export class Import extends Application {
         html.find("button[type='submit']").on("click", async (event) => {
             event.preventDefault();
 
+            let i18nXmlSource = html.find("#i18n-xml-source").val();
+            
+
             let xmlSource = html.find("#xml-source").val();
             await this.parseXML(xmlSource);
         });

--- a/module/apps/import-form.ts
+++ b/module/apps/import-form.ts
@@ -40,6 +40,9 @@ export class Import extends Application {
     }
 
     async parseXmli18n(xmlSource) {
+        if (!xmlSource) {
+            return;
+        }
         let jsonSource = await DataImporter.xml2json(xmlSource);
         
         if (DataImporter.CanParseI18n(jsonSource)) {
@@ -52,6 +55,7 @@ export class Import extends Application {
         html.find("button[type='submit']").on("click", async (event) => {
             event.preventDefault();
 
+            // Don't change order. Translations are needed for Item parsing.
             let i18nXmlSource = html.find("#i18n-xml-source").val();
             await this.parseXmli18n(i18nXmlSource);
 

--- a/module/importer/AmmoImporter.ts
+++ b/module/importer/AmmoImporter.ts
@@ -5,6 +5,7 @@ import Ammo = Shadowrun.Ammo;
 import Weapon = Shadowrun.Weapon;
 
 export class AmmoImporter extends DataImporter {
+    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("gears") && jsonObject["gears"].hasOwnProperty("gear");
     }
@@ -52,7 +53,12 @@ export class AmmoImporter extends DataImporter {
         }
     }
 
+    async ParseTranslation(jsonObject: object) {
+        console.error('implement');
+    }
+
     async Parse(jsonObject: object): Promise<Entity> {
+        const jsonNameTranslations = {};
         let ammoDatas: Ammo[] = [];
         let jsonAmmos = jsonObject["gears"]["gear"];
         for (let i = 0; i < jsonAmmos.length; i++) {

--- a/module/importer/AmmoImporter.ts
+++ b/module/importer/AmmoImporter.ts
@@ -5,7 +5,9 @@ import Ammo = Shadowrun.Ammo;
 import Weapon = Shadowrun.Weapon;
 
 export class AmmoImporter extends DataImporter {
-    public jsoni18n: any;
+    public categoryTranslations: any;
+    public gearsTranslations: any;
+
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("gears") && jsonObject["gears"].hasOwnProperty("gear");
     }
@@ -54,7 +56,13 @@ export class AmmoImporter extends DataImporter {
     }
 
     ExtractTranslation() {
+        if(!DataImporter.jsoni18n) {
+            return;
+        }
 
+        let jsonGeari18n = ImportHelper.ExtractDataFileTranslation(DataImporter.jsoni18n, 'gear.xml');
+        this.categoryTranslations = ImportHelper.ExtractCategoriesTranslation(jsonGeari18n);
+        this.gearsTranslations = ImportHelper.ExtractItemTranslation(jsonGeari18n, 'gears', 'gear');
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
@@ -70,6 +78,7 @@ export class AmmoImporter extends DataImporter {
 
             let data = this.GetDefaultData();
             data.name = ImportHelper.stringValue(jsonData, "name");
+            data.name = ImportHelper.MapNameToTranslation(this.gearsTranslations, data.name);
 
             data.data.description.source = `${ImportHelper.stringValue(jsonData, "source")} ${ImportHelper.stringValue(jsonData, "page")}`;
             data.data.technology.rating = 2;
@@ -98,7 +107,7 @@ export class AmmoImporter extends DataImporter {
             ["grenade", "rocket", "missile"].forEach((compare) => {
                 shouldLookForWeapons = shouldLookForWeapons || nameLower.includes(compare);
             });
-
+            // NOTE: Should either weapons or gear not have been imported with translation, this will fail.
             if (shouldLookForWeapons) {
                 let foundWeapon = ImportHelper.findItem((item) => {
                     return item.name.toLowerCase() === nameLower

--- a/module/importer/AmmoImporter.ts
+++ b/module/importer/AmmoImporter.ts
@@ -53,8 +53,8 @@ export class AmmoImporter extends DataImporter {
         }
     }
 
-    async ParseTranslation(jsonObject: object) {
-        console.error('implement');
+    ExtractTranslation() {
+
     }
 
     async Parse(jsonObject: object): Promise<Entity> {

--- a/module/importer/ArmorImporter.ts
+++ b/module/importer/ArmorImporter.ts
@@ -5,8 +5,8 @@ import Armor = Shadowrun.Armor;
 import {ArmorParserBase} from "../parser/armor/ArmorParserBase";
 
 export class ArmorImporter extends DataImporter {
-    public armorTranslations;
-    public categoryTranslations;
+    public armorTranslations: any;
+    public categoryTranslations: any;
 
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("armors") && jsonObject["armors"].hasOwnProperty("armor");
@@ -55,40 +55,44 @@ export class ArmorImporter extends DataImporter {
         };
     }
 
-    ParseTranslation(jsonObject: object) {
-        DataImporter.jsoni18n = {};
+    ExtractTranslation() {
+        if (!DataImporter.jsoni18n) {
+            return;
+        }
 
-        let tranlsations = jsonObject["chummer"];
-        for (let i = 0; i < tranlsations.length; i++) {
-            const translation = tranlsations[i];
+        let jsonArmori18n;
+        for (let i = 0; i < DataImporter.jsoni18n.length; i++) {
+            const translation = DataImporter.jsoni18n[i];
             if (translation.$.file === 'armor.xml') {
-                DataImporter.jsoni18n = translation;
+                jsonArmori18n = translation;
                 break;
             }
         }
 
-        if (!jsonObject) { 
-            return ;
+        if (!jsonArmori18n) {
+            return;
         }
 
         this.categoryTranslations = {};
         // TODO: Refactor into pretty method
-        if (DataImporter.jsoni18n && DataImporter.jsoni18n.hasOwnProperty("categories")) {
-            DataImporter.jsoni18n.categories.category.forEach(category => {
+        if (jsonArmori18n && jsonArmori18n.hasOwnProperty("categories")) {
+            jsonArmori18n.categories.category.forEach(category => {
                 const name = category[ImportHelper.CHAR_KEY];
-                const translation = category.$.translate;
-                this.categoryTranslations[name] = translation;
+                const translate = category.$.translate;
+                this.categoryTranslations[name] = translate;
             })
         }
 
         this.armorTranslations = {};
-        if (DataImporter.jsoni18n && DataImporter.jsoni18n.hasOwnProperty('armors')) {
-            DataImporter.jsoni18n.armors.armor.forEach(armor => {
+        if (jsonArmori18n && jsonArmori18n.hasOwnProperty('armors')) {
+            jsonArmori18n.armors.armor.forEach(armor => {
                 const name = armor.name[ImportHelper.CHAR_KEY];
-                const translation = armor.translate[ImportHelper.CHAR_KEY];
-                this.armorTranslations[name] = translation;
+                const translate = armor.translate[ImportHelper.CHAR_KEY];
+                this.armorTranslations[name] = translate;
             });
         }
+
+        console.error(this.categoryTranslations, this.armorTranslations);
     }
 
     async Parse(jsonObject: object): Promise<Entity> {

--- a/module/importer/ArmorImporter.ts
+++ b/module/importer/ArmorImporter.ts
@@ -56,13 +56,13 @@ export class ArmorImporter extends DataImporter {
     }
 
     ParseTranslation(jsonObject: object) {
-        let jsoni18n: any = {};
+        DataImporter.jsoni18n = {};
 
         let tranlsations = jsonObject["chummer"];
         for (let i = 0; i < tranlsations.length; i++) {
             const translation = tranlsations[i];
             if (translation.$.file === 'armor.xml') {
-                jsoni18n = translation;
+                DataImporter.jsoni18n = translation;
                 break;
             }
         }
@@ -73,8 +73,8 @@ export class ArmorImporter extends DataImporter {
 
         this.categoryTranslations = {};
         // TODO: Refactor into pretty method
-        if (jsoni18n && jsoni18n.hasOwnProperty("categories")) {
-            jsoni18n.categories.category.forEach(category => {
+        if (DataImporter.jsoni18n && DataImporter.jsoni18n.hasOwnProperty("categories")) {
+            DataImporter.jsoni18n.categories.category.forEach(category => {
                 const name = category[ImportHelper.CHAR_KEY];
                 const translation = category.$.translate;
                 this.categoryTranslations[name] = translation;
@@ -82,8 +82,8 @@ export class ArmorImporter extends DataImporter {
         }
 
         this.armorTranslations = {};
-        if (jsoni18n && jsoni18n.hasOwnProperty('armors')) {
-            jsoni18n.armors.armor.forEach(armor => {
+        if (DataImporter.jsoni18n && DataImporter.jsoni18n.hasOwnProperty('armors')) {
+            DataImporter.jsoni18n.armors.armor.forEach(armor => {
                 const name = armor.name[ImportHelper.CHAR_KEY];
                 const translation = armor.translate[ImportHelper.CHAR_KEY];
                 this.armorTranslations[name] = translation;

--- a/module/importer/ArmorImporter.ts
+++ b/module/importer/ArmorImporter.ts
@@ -60,39 +60,9 @@ export class ArmorImporter extends DataImporter {
             return;
         }
 
-        let jsonArmori18n;
-        for (let i = 0; i < DataImporter.jsoni18n.length; i++) {
-            const translation = DataImporter.jsoni18n[i];
-            if (translation.$.file === 'armor.xml') {
-                jsonArmori18n = translation;
-                break;
-            }
-        }
-
-        if (!jsonArmori18n) {
-            return;
-        }
-
-        this.categoryTranslations = {};
-        // TODO: Refactor into pretty method
-        if (jsonArmori18n && jsonArmori18n.hasOwnProperty("categories")) {
-            jsonArmori18n.categories.category.forEach(category => {
-                const name = category[ImportHelper.CHAR_KEY];
-                const translate = category.$.translate;
-                this.categoryTranslations[name] = translate;
-            })
-        }
-
-        this.armorTranslations = {};
-        if (jsonArmori18n && jsonArmori18n.hasOwnProperty('armors')) {
-            jsonArmori18n.armors.armor.forEach(armor => {
-                const name = armor.name[ImportHelper.CHAR_KEY];
-                const translate = armor.translate[ImportHelper.CHAR_KEY];
-                this.armorTranslations[name] = translate;
-            });
-        }
-
-        console.error(this.categoryTranslations, this.armorTranslations);
+        let jsonArmori18n = ImportHelper.ExtractDataFileTranslation(DataImporter.jsoni18n, 'armor.xml');
+        this.categoryTranslations = ImportHelper.ExtractCategoriesTranslation(jsonArmori18n);
+        this.armorTranslations = ImportHelper.ExtractItemTranslation(jsonArmori18n, 'armors', 'armor');
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
@@ -107,9 +77,7 @@ export class ArmorImporter extends DataImporter {
 
             let data = parser.Parse(jsonData, this.GetDefaultData());
             const category = ImportHelper.stringValue(jsonData, "category").toLowerCase();
-            if (this.armorTranslations && this.armorTranslations.hasOwnProperty(data.name)) {
-                data.name = this.armorTranslations[data.name];
-            }
+            data.name = ImportHelper.MapNameToTranslation(this.armorTranslations, data.name);
             data.folder = folders[category].id;
 
             datas.push(data);

--- a/module/importer/DataImporter.ts
+++ b/module/importer/DataImporter.ts
@@ -3,6 +3,7 @@ import {ImportHelper} from "./ImportHelper";
 const xml2js = require("xml2js");
 
 export abstract class DataImporter {
+    // Stores translations as a whole for implementing classes to extract from without reparsing.
     public static jsoni18n: any;
     /**
      * Get default data for constructing a TItem.

--- a/module/importer/DataImporter.ts
+++ b/module/importer/DataImporter.ts
@@ -3,11 +3,12 @@ import {ImportHelper} from "./ImportHelper";
 const xml2js = require("xml2js");
 
 export abstract class DataImporter {
-
     /**
      * Get default data for constructing a TItem.
      */
     public abstract GetDefaultData(): any;
+
+    public abstract ParseTranslation(jsonObject: object);
 
     /**
      * Validate if this importer is capable of parsing the provided JSON data.
@@ -23,6 +24,10 @@ export abstract class DataImporter {
      */
     public abstract async Parse(jsonObject: object): Promise<Entity>;
 
+    public static CanParseI18n(jsonObject: any): boolean {
+        return jsonObject.hasOwnProperty("chummer") && jsonObject.chummer.length > 0 && jsonObject.chummer[0].$.hasOwnProperty("file");
+    }
+    
     /**
      * Parse an XML string into a JSON object.
      * @param xmlString The string to parse as XML.
@@ -34,6 +39,7 @@ export abstract class DataImporter {
             explicitCharkey: true,
             charkey: ImportHelper.CHAR_KEY
         });
+    
         return (await parser.parseStringPromise(xmlString))["chummer"];
     }
 }

--- a/module/importer/DataImporter.ts
+++ b/module/importer/DataImporter.ts
@@ -9,7 +9,12 @@ export abstract class DataImporter {
      */
     public abstract GetDefaultData(): any;
 
-    public abstract ParseTranslation(jsonObject: object);
+    public static ParseTranslation(jsonObject: object) {
+        if (jsonObject && jsonObject.hasOwnProperty("chummer")) {
+            DataImporter.jsoni18n = jsonObject["chummer"];
+        }
+    }
+    public abstract ExtractTranslation();
 
     /**
      * Validate if this importer is capable of parsing the provided JSON data.

--- a/module/importer/DataImporter.ts
+++ b/module/importer/DataImporter.ts
@@ -3,18 +3,32 @@ import {ImportHelper} from "./ImportHelper";
 const xml2js = require("xml2js");
 
 export abstract class DataImporter {
-    // Stores translations as a whole for implementing classes to extract from without reparsing.
     public static jsoni18n: any;
     /**
      * Get default data for constructing a TItem.
      */
     public abstract GetDefaultData(): any;
 
+    /**
+     * 
+     * @param jsonObject JSON Data with all data translations for one language.
+     */
+    public static CanParseI18n(jsonObject: any): boolean {
+        return jsonObject.hasOwnProperty("chummer") && jsonObject.chummer.length > 0 && jsonObject.chummer[0].$.hasOwnProperty("file");
+    }
+
+    /** 
+     * Stores translations as a whole for all implementing classes to extract from without reparsing.
+     * @param jsonObject JSON Data with all data translations for one language.
+     */
     public static ParseTranslation(jsonObject: object) {
         if (jsonObject && jsonObject.hasOwnProperty("chummer")) {
             DataImporter.jsoni18n = jsonObject["chummer"];
         }
     }
+    /**
+     * Implementing classes can use ExtractTranslation to only extract needed translations.
+     */
     public abstract ExtractTranslation();
 
     /**
@@ -30,10 +44,6 @@ export abstract class DataImporter {
      * @returns An array of created objects.
      */
     public abstract async Parse(jsonObject: object): Promise<Entity>;
-
-    public static CanParseI18n(jsonObject: any): boolean {
-        return jsonObject.hasOwnProperty("chummer") && jsonObject.chummer.length > 0 && jsonObject.chummer[0].$.hasOwnProperty("file");
-    }
     
     /**
      * Parse an XML string into a JSON object.

--- a/module/importer/DataImporter.ts
+++ b/module/importer/DataImporter.ts
@@ -3,6 +3,7 @@ import {ImportHelper} from "./ImportHelper";
 const xml2js = require("xml2js");
 
 export abstract class DataImporter {
+    public static jsoni18n: any;
     /**
      * Get default data for constructing a TItem.
      */

--- a/module/importer/ImportHelper.ts
+++ b/module/importer/ImportHelper.ts
@@ -155,5 +155,47 @@ export class ImportHelper {
 
         return folders;
     }
+
+    public static ExtractDataFileTranslation(jsoni18n, dataFileName): object {
+        for (let i = 0; i < jsoni18n.length; i++) {
+            const translation = jsoni18n[i];
+            if (translation.$.file === dataFileName) {
+                return translation;
+            }
+        }
+        return {};
+    };
+
+    public static ExtractCategoriesTranslation(jsonChummeri18n) {
+        const categoryTranslations = {};
+        if (jsonChummeri18n && jsonChummeri18n.hasOwnProperty("categories")) {
+            jsonChummeri18n.categories.category.forEach(category => {
+                const name = category[ImportHelper.CHAR_KEY];
+                const translate = category.$.translate;
+                categoryTranslations[name] = translate;
+            })
+        }
+        return categoryTranslations;
+    }
+
+    public static ExtractItemTranslation(jsonItemsi18n, typeKey, listKey) {
+        const itemTranslation = {};
+        if (jsonItemsi18n && jsonItemsi18n[typeKey] && jsonItemsi18n[typeKey][listKey] && jsonItemsi18n[typeKey][listKey].length > 0) {
+            jsonItemsi18n[typeKey][listKey].forEach(item => {
+                const name = item.name[ImportHelper.CHAR_KEY];
+                const translate = item.translate[ImportHelper.CHAR_KEY];
+                itemTranslation[name] = translate;
+            })
+        }
+
+        return itemTranslation;
+    }
+
+    public static MapNameToTranslation(translationMap, name): string {
+        if (translationMap && translationMap.hasOwnProperty(name)) {
+            return translationMap[name];
+        }
+        return name;
+    }
 }
 type ItemComparer = (item: Item) => boolean;

--- a/module/importer/ImportHelper.ts
+++ b/module/importer/ImportHelper.ts
@@ -136,16 +136,23 @@ export class ImportHelper {
     }
 
     //TODO
-    public static async MakeCategoryFolders(jsonData: object, path: string): Promise<{ [name: string]: Folder }> {
+    public static async MakeCategoryFolders(jsonData: object, path: string, jsonCategoryTranslations?: object | undefined): Promise<{ [name: string]: Folder }> {
         let folders = {};
         let jsonCategories = jsonData["categories"]["category"];
+
         for (let i = 0; i < jsonCategories.length; i++) {
             let categoryName = jsonCategories[i][ImportHelper.CHAR_KEY];
-            folders[categoryName.toLowerCase()] = await ImportHelper.GetFolderAtPath(
+            // use untranslated category name for easier mapping during DataImporter.Parse implementations.
+            let origCategoryName = categoryName;
+            if (jsonCategoryTranslations && jsonCategoryTranslations.hasOwnProperty(categoryName)) {
+                categoryName = jsonCategoryTranslations[categoryName];
+            }
+            folders[origCategoryName.toLowerCase()] = await ImportHelper.GetFolderAtPath(
                 `${Constants.ROOT_IMPORT_FOLDER_NAME}/${path}/${categoryName}`,
                 true
             );
         }
+
         return folders;
     }
 }

--- a/module/importer/ModImporter.ts
+++ b/module/importer/ModImporter.ts
@@ -5,6 +5,7 @@ import {Constants} from "./Constants";
 import MountType = Shadowrun.MountType;
 
 export class ModImporter extends DataImporter {
+    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("accessories") && jsonObject["accessories"].hasOwnProperty("accessory");
     }
@@ -48,7 +49,12 @@ export class ModImporter extends DataImporter {
         }
     }
 
+    ParseTranslation(jsonObject: object) {
+        
+    }
+
     async Parse(jsonObject: object): Promise<Entity> {
+        const jsonNameTranslations = {};
         let modDatas: Mod[] = [];
         let jsonAccs = jsonObject["accessories"]["accessory"];
         for (let i = 0; i < jsonAccs.length; i++) {

--- a/module/importer/ModImporter.ts
+++ b/module/importer/ModImporter.ts
@@ -5,7 +5,9 @@ import {Constants} from "./Constants";
 import MountType = Shadowrun.MountType;
 
 export class ModImporter extends DataImporter {
-    public jsoni18n: any;
+    public categoryTranslations: any;
+    public accessoryTranslations: any;
+
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("accessories") && jsonObject["accessories"].hasOwnProperty("accessory");
     }
@@ -50,11 +52,16 @@ export class ModImporter extends DataImporter {
     }
 
     ExtractTranslation() {
+        if (!DataImporter.jsoni18n) {
+            return;
+        }
 
+        let jsonWeaponsi18n = ImportHelper.ExtractDataFileTranslation(DataImporter.jsoni18n, 'weapons.xml');
+        // Parts of weapon accessory translations are within the application translation. Currently only data translation is used.
+        this.accessoryTranslations = ImportHelper.ExtractItemTranslation(jsonWeaponsi18n, 'accessories', 'accessory');
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
-        const jsonNameTranslations = {};
         let modDatas: Mod[] = [];
         let jsonAccs = jsonObject["accessories"]["accessory"];
         for (let i = 0; i < jsonAccs.length; i++) {
@@ -63,6 +70,7 @@ export class ModImporter extends DataImporter {
             let data = this.GetDefaultData();
 
             data.name = ImportHelper.stringValue(jsonData, "name");
+            data.name = ImportHelper.MapNameToTranslation(this.accessoryTranslations, data.name);
 
             data.data.description.source = `${ImportHelper.stringValue(jsonData, "source")} ${ImportHelper.stringValue(jsonData, "page")}`;
 

--- a/module/importer/ModImporter.ts
+++ b/module/importer/ModImporter.ts
@@ -49,8 +49,8 @@ export class ModImporter extends DataImporter {
         }
     }
 
-    ParseTranslation(jsonObject: object) {
-        
+    ExtractTranslation() {
+
     }
 
     async Parse(jsonObject: object): Promise<Entity> {

--- a/module/importer/QualityImporter.ts
+++ b/module/importer/QualityImporter.ts
@@ -74,7 +74,7 @@ export class QualityImporter extends DataImporter {
         };
     }
 
-    ParseTranslation(jsonObject: object) {
+    ExtractTranslation() {
     }
 
     async Parse(jsonObject: object): Promise<Entity> {

--- a/module/importer/QualityImporter.ts
+++ b/module/importer/QualityImporter.ts
@@ -4,6 +4,7 @@ import {QualityParserBase} from "../parser/quality/QualityParserBase";
 import Quality = Shadowrun.Quality;
 
 export class QualityImporter extends DataImporter {
+    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("qualities") && jsonObject["qualities"].hasOwnProperty("quality");
     }
@@ -73,7 +74,11 @@ export class QualityImporter extends DataImporter {
         };
     }
 
+    ParseTranslation(jsonObject: object) {
+    }
+
     async Parse(jsonObject: object): Promise<Entity> {
+        const jsonNameTranslations = {};
         const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Qualities");
         console.log(folders);
 

--- a/module/importer/QualityImporter.ts
+++ b/module/importer/QualityImporter.ts
@@ -4,7 +4,9 @@ import {QualityParserBase} from "../parser/quality/QualityParserBase";
 import Quality = Shadowrun.Quality;
 
 export class QualityImporter extends DataImporter {
-    public jsoni18n: any;
+    public categoryTranslations: any;
+    public qualityTranslations: any;
+
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("qualities") && jsonObject["qualities"].hasOwnProperty("quality");
     }
@@ -75,11 +77,18 @@ export class QualityImporter extends DataImporter {
     }
 
     ExtractTranslation() {
+        if(!DataImporter.jsoni18n) {
+            return;
+        }
+
+        let jsonQualityi18n = ImportHelper.ExtractDataFileTranslation(DataImporter.jsoni18n, 'qualities.xml');
+        this.categoryTranslations = ImportHelper.ExtractCategoriesTranslation(jsonQualityi18n);
+        this.qualityTranslations = ImportHelper.ExtractItemTranslation(jsonQualityi18n, 'qualities', 'quality');
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
         const jsonNameTranslations = {};
-        const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Qualities");
+        const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Qualities", this.categoryTranslations);
         console.log(folders);
 
         const parser = new QualityParserBase();
@@ -92,6 +101,7 @@ export class QualityImporter extends DataImporter {
 
             let category = ImportHelper.stringValue(jsonData, "category");
             data.folder = folders[category.toLowerCase()].id;
+            data.name = ImportHelper.MapNameToTranslation(this.qualityTranslations, data.name);
 
             datas.push(data);
         }

--- a/module/importer/SpellImporter.ts
+++ b/module/importer/SpellImporter.ts
@@ -101,8 +101,8 @@ export class SpellImporter extends DataImporter {
         };
     }
 
-    ParseTranslation(jsonObject: object) {
-        
+    ExtractTranslation() {
+
     }
 
     async Parse(jsonObject: object): Promise<Entity> {

--- a/module/importer/SpellImporter.ts
+++ b/module/importer/SpellImporter.ts
@@ -9,6 +9,7 @@ import {DetectionSpellImporter} from "../parser/spell/DetectionSpellImporter";
 import {ParserMap} from "../parser/ParserMap";
 
 export class SpellImporter extends DataImporter {
+    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("spells") && jsonObject["spells"].hasOwnProperty("spell");
     }
@@ -100,7 +101,12 @@ export class SpellImporter extends DataImporter {
         };
     }
 
+    ParseTranslation(jsonObject: object) {
+        
+    }
+
     async Parse(jsonObject: object): Promise<Entity> {
+        const jsonNameTranslations = {};
         const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Spells");
 
         const parser = new ParserMap<Spell>("category", [

--- a/module/importer/WeaponImporter.ts
+++ b/module/importer/WeaponImporter.ts
@@ -15,7 +15,6 @@ export class WeaponImporter extends DataImporter {
     public categoryTranslations: any;
     public weaponTranslations: any;
 
-    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("weapons") && jsonObject["weapons"].hasOwnProperty("weapon");
     }

--- a/module/importer/WeaponImporter.ts
+++ b/module/importer/WeaponImporter.ts
@@ -148,7 +148,13 @@ export class WeaponImporter extends DataImporter {
     }
 
     ExtractTranslation() {
+        if (!DataImporter.jsoni18n) {
+            return;
+        }
 
+        let jsonWeaponi18n = ImportHelper.ExtractDataFileTranslation(DataImporter.jsoni18n, 'weapons.xml');
+        this.categoryTranslations = ImportHelper.ExtractCategoriesTranslation(jsonWeaponi18n);
+        this.weaponTranslations = ImportHelper.ExtractItemTranslation(jsonWeaponi18n, 'weapons', 'weapon');
     }
 
     private static GetWeaponType(weaponJson: object): WeaponCategory {
@@ -173,20 +179,15 @@ export class WeaponImporter extends DataImporter {
 
     async Parse(jsonObject: object): Promise<Entity> {
         const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Weapons", this.categoryTranslations);
-        const gearCategory = "gear";
-        const qualityCategory = "quality";
-
-
-        folders[gearCategory] = await ImportHelper.GetFolderAtPath(
+        
+        folders["gear"] = await ImportHelper.GetFolderAtPath(
             `${Constants.ROOT_IMPORT_FOLDER_NAME}/Weapons/Gear`,
             true
         );
-        folders[gearCategory] = await ImportHelper.GetFolderAtPath(
+        folders["quality"] = await ImportHelper.GetFolderAtPath(
             `${Constants.ROOT_IMPORT_FOLDER_NAME}/Weapons/Quality`,
             true
         );
-
-        console.log(folders);
 
         const parser = new ParserMap<Weapon>(WeaponImporter.GetWeaponType, [
             { key: "range", value: new RangedParser() },
@@ -201,6 +202,8 @@ export class WeaponImporter extends DataImporter {
 
             let data = parser.Parse(jsonData, this.GetDefaultData());
             data.folder = folders[data.data.category].id;
+
+            data.name = ImportHelper.MapNameToTranslation(this.weaponTranslations, data.name);
 
             datas.push(data);
         }

--- a/module/importer/WeaponImporter.ts
+++ b/module/importer/WeaponImporter.ts
@@ -12,6 +12,7 @@ import DamageType = Shadowrun.DamageType;
 import {ParserMap} from "../parser/ParserMap";
 
 export class WeaponImporter extends DataImporter {
+    public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("weapons") && jsonObject["weapons"].hasOwnProperty("weapon");
     }
@@ -143,6 +144,9 @@ export class WeaponImporter extends DataImporter {
         };
     }
 
+    ParseTranslation(jsonObject: object) {
+    }
+
     private static GetWeaponType(weaponJson: object): WeaponCategory {
         let type = ImportHelper.stringValue(weaponJson, "type");
         //melee is the least specific, all melee entries are accurate
@@ -164,6 +168,8 @@ export class WeaponImporter extends DataImporter {
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
+        const jsonNameTranslations = {};
+
         const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Weapons");
         folders["gear"] = await ImportHelper.GetFolderAtPath(
             `${Constants.ROOT_IMPORT_FOLDER_NAME}/Weapons/Gear`,

--- a/module/importer/WeaponImporter.ts
+++ b/module/importer/WeaponImporter.ts
@@ -12,6 +12,9 @@ import DamageType = Shadowrun.DamageType;
 import {ParserMap} from "../parser/ParserMap";
 
 export class WeaponImporter extends DataImporter {
+    public categoryTranslations: any;
+    public weaponTranslations: any;
+
     public jsoni18n: any;
     CanParse(jsonObject: object): boolean {
         return jsonObject.hasOwnProperty("weapons") && jsonObject["weapons"].hasOwnProperty("weapon");
@@ -144,7 +147,8 @@ export class WeaponImporter extends DataImporter {
         };
     }
 
-    ParseTranslation(jsonObject: object) {
+    ExtractTranslation() {
+
     }
 
     private static GetWeaponType(weaponJson: object): WeaponCategory {
@@ -168,14 +172,16 @@ export class WeaponImporter extends DataImporter {
     }
 
     async Parse(jsonObject: object): Promise<Entity> {
-        const jsonNameTranslations = {};
+        const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Weapons", this.categoryTranslations);
+        const gearCategory = "gear";
+        const qualityCategory = "quality";
 
-        const folders = await ImportHelper.MakeCategoryFolders(jsonObject, "Weapons");
-        folders["gear"] = await ImportHelper.GetFolderAtPath(
+
+        folders[gearCategory] = await ImportHelper.GetFolderAtPath(
             `${Constants.ROOT_IMPORT_FOLDER_NAME}/Weapons/Gear`,
             true
         );
-        folders["quality"] = await ImportHelper.GetFolderAtPath(
+        folders[gearCategory] = await ImportHelper.GetFolderAtPath(
             `${Constants.ROOT_IMPORT_FOLDER_NAME}/Weapons/Quality`,
             true
         );

--- a/templates/apps/compendium-import.html
+++ b/templates/apps/compendium-import.html
@@ -6,9 +6,9 @@
     <section>
         <div class="flexcol">
             <label for="xml-source">Source Text</label>
-            <textarea style="min-height: 400px" id="xml-source">
-              
-</textarea>
+            <textarea style="min-height: 400px" id="xml-source"></textarea>
+            <label for="i18n-xml-source">Translation Text (de-de_data.xml)</label>
+            <textarea style="min-height: 400px" id="i18n-xml-source"></textarea>
         </div>
         <button type="submit">Import</button>
     </section>

--- a/templates/apps/compendium-import.html
+++ b/templates/apps/compendium-import.html
@@ -7,7 +7,7 @@
         <div class="flexcol">
             <label for="xml-source">Source Text</label>
             <textarea style="min-height: 400px" id="xml-source"></textarea>
-            <label for="i18n-xml-source">Translation Text (de-de_data.xml)</label>
+            <label for="i18n-xml-source">Translation Text (de-de_data.xml) (optional)</label>
             <textarea style="min-height: 400px" id="i18n-xml-source"></textarea>
         </div>
         <button type="submit">Import</button>


### PR DESCRIPTION
Just so you are aware: I've added optional i18n support based on the *-*_data.xml translations from Chummer5 for the currently supported files. I'll keep adding this feature to new file imports on my fork. Item folder name translations aren't part of Chummer5 translation model and therefore won't be translated. However item names and categories mostly are (some data translations are within the Chummer5 application translation and aren't easily mappable to data...)

I tested the imports with and without translation for all currently supported file imports and I'll try to keep adding translations for newly added data files imports. The DataImporter.ExtractTranslation and Parse implementations are what mostly needs to be considered for new translations.

Enjoy your day and keep up the good work :)